### PR TITLE
term not used since #48588

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -245,9 +245,6 @@ fn publish(pkg: &Package, commit: &str, vers: &semver::Version) {
         //   at the `vers` specified above
         // * Update the name of `path` dependencies to what we're publishing,
         //   which is crates with a prefix.
-        // * Synthesize a dependency on `term`. Currently crates depend on
-        //   `term` through the sysroot instead of via `Cargo.toml`, so we need
-        //   to change that for the published versions.
         if let Some(deps) = toml.remove("dependencies") {
             let mut deps = deps.as_table().unwrap().iter().map(|(name, dep)| {
                 let table = match dep.as_table() {
@@ -266,7 +263,6 @@ fn publish(pkg: &Package, commit: &str, vers: &semver::Version) {
                 );
                 (format!("{}-{}", PREFIX, name), new_table.into())
             }).collect::<Vec<_>>();
-            deps.push(("term".to_string(), "0.4".to_string().into()));
             toml.insert(
                 "dependencies".to_string(),
                 toml::Value::Table(deps.into_iter().collect()),


### PR DESCRIPTION
think that this can be removed due to termcolor is used now but have no idea how to test it.
had some problems to find why term 0.4.6 was added to the rustc Cargo.lock file until I fund this crate 