### PR TITLE
changed insertion of 'rustc_private' to more naive approach

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -354,10 +354,7 @@ fn alter_lib_rs(path: &Path) {
 
     // Inject #![feature(rustc_private)]. This is a hack, let's fix upstream so
     // we don't have to do this.
-    let needle = "\n#![feature(";
-    if let Some(i) = contents.find(needle) {
-        contents.insert_str(i + needle.len(), "rustc_private, ");
-    }
+    contents.insert_str(0, "#![feature(rustc_private)]\n");
 
     // Delete __build_diagnostic_array!. This is a hack, let's fix upstream so
     // we don't have to do this.


### PR DESCRIPTION
The 'rustc_private' feature is not inserted in the case of the
rustc-ap-rustc_lexer crate.

To fix this error we just insert a completely new feature attribute
instead of try to prepend it to an already existing one.