### PR TITLE
Try to fix rust-lang/rust#62558

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -308,14 +308,8 @@ fn publish(pkg: &Package, commit: &str, vers: &semver::Version) {
                             "package".to_string(),
                             toml::Value::String(format!("{}-{}", PREFIX, name)),
                         );
-                        has_package = true;
                     }
-                    let key_name = if has_package {
-                        name.clone()
-                    } else {
-                        format!("{}-{}", PREFIX, name)
-                    };
-                    (key_name, new_table.into())
+                    (name.clone(), new_table.into())
                 })
                 .collect::<Vec<_>>();
             toml.insert(

--- a/src/main.rs
+++ b/src/main.rs
@@ -303,6 +303,13 @@ fn publish(pkg: &Package, commit: &str, vers: &semver::Version) {
                         }
                     }
                     new_table.insert("version".to_string(), toml::Value::String(vers.to_string()));
+                    if !has_package {
+                        new_table.insert(
+                            "package".to_string(),
+                            toml::Value::String(format!("{}-{}", PREFIX, name)),
+                        );
+                        has_package = true;
+                    }
                     let key_name = if has_package {
                         name.clone()
                     } else {


### PR DESCRIPTION
This PR will automatically add `package=...` property into dependency entries without this property and keep the original crate names so that Cargo will automatically pass proper `--extern <name>=...` flags.
Attempts to fix https://github.com/rust-lang/rust/issues/62558