### PR TITLE
Remove setting lib.name

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -270,6 +270,7 @@ fn publish(pkg: &Package, commit: &str, vers: &semver::Version) {
         // so it's not compiled as a dylib.
         if let Some(lib) = toml.get_mut("lib") {
             let lib = lib.as_table_mut().unwrap();
+            lib.remove("name");
             lib.remove("crate-type");
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -265,9 +265,8 @@ fn publish(pkg: &Package, commit: &str, vers: &semver::Version) {
             );
         }
 
-        // Fill in the `[lib]` section with an extra `name` key indicating the
-        // original name (so the crate name is right). Also remove `crate-type`
-        // so it's not compiled as a dylib.
+        // Remove `crate-type` so it's not compiled as a dylib.
+        // Also remove `lib` to force rename the crates.
         if let Some(lib) = toml.get_mut("lib") {
             let lib = lib.as_table_mut().unwrap();
             lib.remove("name");

--- a/src/main.rs
+++ b/src/main.rs
@@ -270,8 +270,6 @@ fn publish(pkg: &Package, commit: &str, vers: &semver::Version) {
         // so it's not compiled as a dylib.
         if let Some(lib) = toml.get_mut("lib") {
             let lib = lib.as_table_mut().unwrap();
-            let name = pkg.name.to_string();
-            lib.insert("name".to_string(), toml::Value::String(name));
             lib.remove("crate-type");
         }
 


### PR DESCRIPTION
This is a follow up to #11. This make sure rustc-ap-rustc_macros is librustc_ap_rustc_macros.so and not librustc_macros.so to prevent confusing the compiler.
This is a temporary hack until the compiler can properly disambiguate which proc macro crate to use when cross compiling.