### PR TITLE
add rustc_expand to pub list

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,10 @@ fn main() {
             name: "rustc_parse",
             dir: "src/librustc_parse",
         },
+        RustcApCrate {
+            name: "rustc_expand",
+            dir: "src/librustc_expand",
+        },
     ];
 
     println!("learning about the dependency graph");


### PR DESCRIPTION
Looks like rustfmt will need `rustc_expand` as well due to some of the recent changes to the parser

Refs https://github.com/rust-lang/rust/issues/70280