### PR TITLE
Remove unnecessary extern crate declarations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,5 @@
 #[macro_use]
 extern crate serde_derive;
-extern crate curl;
-extern crate flate2;
-extern crate semver;
-extern crate serde_json;
-extern crate tar;
-extern crate tempdir;
-extern crate toml;
 
 use std::collections::{BTreeMap, HashSet};
 use std::fs::{self, File};


### PR DESCRIPTION
This PR removes the unnecessary extern crate declarations.

The content of the PR is not that important: the real purpose is to push whatever commit to the master branch and get GitHub Action going so that the new rustc-ap-* crates get published.

