### PR TITLE
update crate listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # rustc-auto-publish
 
-Repository for automatically publishing the `rustc-ap-rustc_ast` and
-`rustc-ap-rustc_parse` crates once a week.
+Repository for automatically publishing the below crates once a week.
 
+- `rustc-ap-rustc_ast`
+- `rustc-ap-rustc_expand`
+- `rustc-ap-rustc_parse`


### PR DESCRIPTION
The primary purpose of this PR is to trigger the a publish of these crates. There were a couple PRs in rustc that we needed to address some things on the rustfmt side, but they didn't all land before the publish a few days ago.