### PR TITLE
include crate links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 Repository for automatically publishing the below crates once a week.
 
-- `rustc-ap-rustc_ast`
-- `rustc-ap-rustc_expand`
-- `rustc-ap-rustc_parse`
+- [rustc-ap-rustc_ast](https://crates.io/crates/rustc-ap_rustc_ast)
+- [rustc-ap-rustc_expand](https://crates.io/crates/rustc-ap_rustc_expand)
+- [rustc-ap-rustc_parse](https://crates.io/crates/rustc-ap_rustc_parse)


### PR DESCRIPTION
The real objective here is to try to get an early publish of the crates as we have a broken toolstate issue with rustfmt, and need some recently merged changes in rustc to be able to proceed.

Refs https://github.com/rust-lang/rust/issues/79407 and https://github.com/rust-lang/rust/pull/79433

r? @alexcrichton 