### PR TITLE
trigger early publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rustc-auto-publish
 
-Repository for automatically publishing the below crates once a week.
+Repository for automatically publishing the below crates every Tuesday.
 
 - [rustc-ap-rustc_ast](https://crates.io/crates/rustc-ap_rustc_ast)
 - [rustc-ap-rustc_expand](https://crates.io/crates/rustc-ap_rustc_expand)


### PR DESCRIPTION
Another dummy commit to hopefully trigger an early publish so that we can get the updates containing 2021 edition changes. Refs a mix of open issues/PRs (https://github.com/rust-lang/rust/issues/80576, https://github.com/rust-lang/rls/pull/1709, https://github.com/rust-lang/rustfmt/pull/4618)