### PR TITLE
trigger early release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Repository for automatically publishing the below crates every Tuesday.
 
-- [rustc-ap-rustc_ast](https://crates.io/crates/rustc-ap_rustc_ast)
+- [rustc-ap-rustc_ast][rustc-ast-crate] [![rustc_ast version][rustc-ast-version-badge]][rustc-ast-crate]
 - [rustc-ap-rustc_expand](https://crates.io/crates/rustc-ap_rustc_expand)
 - [rustc-ap-rustc_parse](https://crates.io/crates/rustc-ap_rustc_parse)
+
+[rustc-ast-version-badge]: https://img.shields.io/crates/v/rustc-ap_rustc_ast?style=flat-square
+[rustc-ast-crate]: https://crates.io/crates/rustc-ap_rustc_ast


### PR DESCRIPTION
The main purpose is to request another early publish to address broken toolstate issues with RLS and rustfmt on nightly. As noted on https://github.com/rust-lang/rust/pull/81768 things in rustc changed on us and we have to restart the upgrade dance, so hoping to get an early start if possible

refs https://github.com/rust-lang/rust/issues/81583 and https://github.com/rust-lang/rust/issues/81582

regarding the actual change here... :smile: I'd run out of ideas for changes to trigger a release, so figured why not add a badge that shows the latest crate version