### PR TITLE
increase publish wait time

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ fn main() {
         publish(p, &commit, &version_to_publish);
 
         // Give the crates time to make their way into the index
-        thread::sleep(Duration::from_secs(20));
+        thread::sleep(Duration::from_secs(45));
     }
 }
 


### PR DESCRIPTION
Couple recent failures that seem likely to be caused by delays on the index updates. Increasing the wait time to see if that resolves